### PR TITLE
Removed accidental const that caused some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(lgmath)
 ################################################################################
 ### Misc
 ################################################################################
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -std=c++11")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic -std=c++0x")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -mno-avx")
 

--- a/include/lgmath/se3/TransformationWithCovariance.hpp
+++ b/include/lgmath/se3/TransformationWithCovariance.hpp
@@ -162,7 +162,7 @@ class TransformationWithCovariance: public Transformation
   /// \brief Returns whether or not a covariance has been set. If it is unset, then querying it
   ///        with the public method cov() will throw an exception.
   //////////////////////////////////////////////////////////////////////////////////////////////
-  const bool covarianceSet() const;
+  bool covarianceSet() const;
 
   //////////////////////////////////////////////////////////////////////////////////////////////
   /// \brief Sets the underlying rotation matrix

--- a/src/se3/TransformationWithCovariance.cpp
+++ b/src/se3/TransformationWithCovariance.cpp
@@ -186,7 +186,7 @@ const Eigen::Matrix<double,6,6>& TransformationWithCovariance::cov() const {
 /// \brief Returns whether or not a covariance has been set. If it is unset, then querying it
 ///        with the public method cov() will throw an exception.
 //////////////////////////////////////////////////////////////////////////////////////////////
-const bool TransformationWithCovariance::covarianceSet() const {
+bool TransformationWithCovariance::covarianceSet() const {
   return covarianceSet_;
 }
 


### PR DESCRIPTION
Stupid minor change, but the warning was annoying.
