### PR TITLE
Remove ROS2 Branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 project(lgmath)
 
-option(USE_AMENT "Use ament_cmake to build lgmath for ROS2." OFF)
+find_package(ament_cmake QUIET)
 
 # Compiler setup
 set(CMAKE_CXX_STANDARD 17)
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-march=native -O3 -Wall -pedantic)
 
 ## cmake flow (default)
-if (NOT USE_AMENT)
+if (NOT ament_cmake_FOUND)
 
 set(PROJECT_VERSION 1.1.0)
 
@@ -124,7 +124,6 @@ endif()
 ## ROS2 ament_cmake flow
 else()
 
-find_package(ament_cmake REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 3.3.7 REQUIRED)
 
@@ -211,6 +210,6 @@ else(DOXYGEN_FOUND)
     COMMENT "Doxygen was not found on this system so this target does not exist, please install it and re-run CMake." VERBATIM)
 endif(DOXYGEN_FOUND)
 
-if (USE_AMENT)
+if (ament_cmake_FOUND)
 ament_package()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,189 +9,191 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_compile_options(-march=native -O3 -Wall -pedantic)
 
 ## cmake flow (default)
-if (NOT ament_cmake_FOUND)
+if ((NOT ament_cmake_FOUND) OR ("/usr/local" STREQUAL ${CMAKE_INSTALL_PREFIX}))
+  message(STATUS "Not using ROS to build")
 
-set(PROJECT_VERSION 1.1.0)
+  set(PROJECT_VERSION 1.1.0)
 
-# Find dependencies
-find_package(Eigen3 3.3.7 REQUIRED)
+  # Find dependencies
+  find_package(Eigen3 3.3.7 REQUIRED)
 
-# Build library
-file(GLOB_RECURSE SOURCE_FILES "src/*.cpp")
-add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
-target_include_directories(${PROJECT_NAME}
-  PUBLIC
-    ${EIGEN3_INCLUDE_DIR}
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
+  # Build library
+  file(GLOB_RECURSE SOURCE_FILES "src/*.cpp")
+  add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+  target_include_directories(${PROJECT_NAME}
+    PUBLIC
+      ${EIGEN3_INCLUDE_DIR}
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+  )
 
-# Install
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+  # Install
+  install(
+    DIRECTORY include/
+    DESTINATION include
+  )
 
-install(
-  TARGETS ${PROJECT_NAME}
-  DESTINATION lib
-  EXPORT ${PROJECT_NAME}Targets
-)
+  install(
+    TARGETS ${PROJECT_NAME}
+    DESTINATION lib
+    EXPORT ${PROJECT_NAME}Targets
+  )
 
-# Export
-set(PROJECT_LIBRARY ${PROJECT_NAME})
+  # Export
+  set(PROJECT_LIBRARY ${PROJECT_NAME})
 
-include(CMakePackageConfigHelpers)
-configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
-  NO_SET_AND_CHECK_MACRO
-  NO_CHECK_REQUIRED_COMPONENTS_MACRO
-)
-write_basic_package_version_file(
-  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-  VERSION ${PROJECT_VERSION}
-  COMPATIBILITY AnyNewerVersion
-)
-# export to build directory so no need to install in order to use find_package
-export(
-  EXPORT ${PROJECT_NAME}Targets
-  FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
-)
-
-# install export cmake files
-install(
-  EXPORT ${PROJECT_NAME}Targets
-  FILE ${PROJECT_NAME}Targets.cmake
-  DESTINATION lib/cmake/${PROJECT_NAME}
-)
-
-install(
-  FILES
+  include(CMakePackageConfigHelpers)
+  configure_package_config_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+    INSTALL_DESTINATION lib/cmake/${PROJECT_NAME}
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+  write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-  DESTINATION lib/cmake/${PROJECT_NAME}
-)
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+  )
+  # export to build directory so no need to install in order to use find_package
+  export(
+    EXPORT ${PROJECT_NAME}Targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake
+  )
 
-# Tests (for default cmake flow)
-if(BUILD_TESTING)
-  find_package(GTest REQUIRED)
-  enable_testing()
+  # install export cmake files
+  install(
+    EXPORT ${PROJECT_NAME}Targets
+    FILE ${PROJECT_NAME}Targets.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME}
+  )
 
-  # Unit-tests
-  add_executable(so2_tests tests/SO2Tests.cpp)
-  target_link_libraries(so2_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME so2_tests COMMAND so2_tests)
+  install(
+    FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+      ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION lib/cmake/${PROJECT_NAME}
+  )
 
-  add_executable(so3_tests tests/SO3Tests.cpp)
-  target_link_libraries(so3_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME so3_tests COMMAND so3_tests)
+  # Tests (for default cmake flow)
+  if(BUILD_TESTING)
+    find_package(GTest REQUIRED)
+    enable_testing()
 
-  add_executable(se2_tests tests/SE2Tests.cpp)
-  target_link_libraries(se2_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME se2_tests COMMAND se2_tests)
-  
-  add_executable(se3_tests tests/SE3Tests.cpp)
-  target_link_libraries(se3_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME se3_tests COMMAND se3_tests)
-  
-  add_executable(covariance_tests tests/CovarianceTests.cpp)
-  target_link_libraries(covariance_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME covariance_tests COMMAND covariance_tests)
-  
-  add_executable(rotation_tests tests/RotationTests.cpp)
-  target_link_libraries(rotation_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME rotation_tests COMMAND rotation_tests)
-  
-  add_executable(se2_transform_tests tests/SE2TransformTests.cpp)
-  target_link_libraries(se2_transform_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME se2_transform_tests COMMAND se2_transform_tests)
+    # Unit-tests
+    add_executable(so2_tests tests/SO2Tests.cpp)
+    target_link_libraries(so2_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME so2_tests COMMAND so2_tests)
 
-  add_executable(transform_tests tests/TransformTests.cpp)
-  target_link_libraries(transform_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME transform_tests COMMAND transform_tests)
-  
-  add_executable(transform_with_covariance_tests tests/TransformWithCovarianceTests.cpp)
-  target_link_libraries(transform_with_covariance_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME transform_with_covariance_tests COMMAND transform_with_covariance_tests)
+    add_executable(so3_tests tests/SO3Tests.cpp)
+    target_link_libraries(so3_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME so3_tests COMMAND so3_tests)
 
-  add_executable(se2_transform_with_covariance_tests tests/SE2TransformWithCovarianceTests.cpp)
-  target_link_libraries(se2_transform_with_covariance_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
-  add_test(NAME se2_transform_with_covariance_tests COMMAND se2_transform_with_covariance_tests)
-endif()
+    add_executable(se2_tests tests/SE2Tests.cpp)
+    target_link_libraries(se2_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME se2_tests COMMAND se2_tests)
+    
+    add_executable(se3_tests tests/SE3Tests.cpp)
+    target_link_libraries(se3_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME se3_tests COMMAND se3_tests)
+    
+    add_executable(covariance_tests tests/CovarianceTests.cpp)
+    target_link_libraries(covariance_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME covariance_tests COMMAND covariance_tests)
+    
+    add_executable(rotation_tests tests/RotationTests.cpp)
+    target_link_libraries(rotation_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME rotation_tests COMMAND rotation_tests)
+    
+    add_executable(se2_transform_tests tests/SE2TransformTests.cpp)
+    target_link_libraries(se2_transform_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME se2_transform_tests COMMAND se2_transform_tests)
+
+    add_executable(transform_tests tests/TransformTests.cpp)
+    target_link_libraries(transform_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME transform_tests COMMAND transform_tests)
+    
+    add_executable(transform_with_covariance_tests tests/TransformWithCovarianceTests.cpp)
+    target_link_libraries(transform_with_covariance_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME transform_with_covariance_tests COMMAND transform_with_covariance_tests)
+
+    add_executable(se2_transform_with_covariance_tests tests/SE2TransformWithCovarianceTests.cpp)
+    target_link_libraries(se2_transform_with_covariance_tests ${PROJECT_NAME} GTest::gtest GTest::gtest_main)
+    add_test(NAME se2_transform_with_covariance_tests COMMAND se2_transform_with_covariance_tests)
+  endif()
 
 ## ROS2 ament_cmake flow
 else()
+  message(STATUS "Using ROS to build")
 
-find_package(eigen3_cmake_module REQUIRED)
-find_package(Eigen3 3.3.7 REQUIRED)
+  find_package(eigen3_cmake_module REQUIRED)
+  find_package(Eigen3 3.3.7 REQUIRED)
 
-file(GLOB_RECURSE SOURCE src/*.cpp)
-add_library(${PROJECT_NAME} ${SOURCE})
-ament_target_dependencies(${PROJECT_NAME} Eigen3)
-target_include_directories(${PROJECT_NAME}
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>)
+  file(GLOB_RECURSE SOURCE src/*.cpp)
+  add_library(${PROJECT_NAME} ${SOURCE})
+  ament_target_dependencies(${PROJECT_NAME} Eigen3)
+  target_include_directories(${PROJECT_NAME}
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>)
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+  install(
+    DIRECTORY include/
+    DESTINATION include
+  )
 
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
-  INCLUDES DESTINATION include
-)
+  install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT export_${PROJECT_NAME}
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+    INCLUDES DESTINATION include
+  )
 
-ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+  ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
-if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
 
-  # Unit-tests
-  ament_add_gtest(so2_tests tests/SO2Tests.cpp)
-  target_link_libraries(so2_tests ${PROJECT_NAME})
-  ament_add_gtest(so3_tests tests/SO3Tests.cpp)
-  target_link_libraries(so3_tests ${PROJECT_NAME})
-  ament_add_gtest(se2_tests tests/SE2Tests.cpp)
-  target_link_libraries(se2_tests ${PROJECT_NAME})
-  ament_add_gtest(se3_tests tests/SE3Tests.cpp)
-  target_link_libraries(se3_tests ${PROJECT_NAME})
-  ament_add_gtest(covariance_tests tests/CovarianceTests.cpp)
-  target_link_libraries(covariance_tests ${PROJECT_NAME})
-  ament_add_gtest(rotation_tests tests/RotationTests.cpp)
-  target_link_libraries(rotation_tests ${PROJECT_NAME})
-  ament_add_gtest(se2_transform_tests tests/SE2TransformTests.cpp)
-  target_link_libraries(se2_transform_tests ${PROJECT_NAME})
-  ament_add_gtest(transform_tests tests/TransformTests.cpp)
-  target_link_libraries(transform_tests ${PROJECT_NAME})
-  ament_add_gtest(se2_transform_with_covariance_tests tests/SE2TransformWithCovarianceTests.cpp)
-  target_link_libraries(se2_transform_with_covariance_tests ${PROJECT_NAME})
-  ament_add_gtest(transform_with_covariance_tests tests/TransformWithCovarianceTests.cpp)
-  target_link_libraries(transform_with_covariance_tests ${PROJECT_NAME})
+    # Unit-tests
+    ament_add_gtest(so2_tests tests/SO2Tests.cpp)
+    target_link_libraries(so2_tests ${PROJECT_NAME})
+    ament_add_gtest(so3_tests tests/SO3Tests.cpp)
+    target_link_libraries(so3_tests ${PROJECT_NAME})
+    ament_add_gtest(se2_tests tests/SE2Tests.cpp)
+    target_link_libraries(se2_tests ${PROJECT_NAME})
+    ament_add_gtest(se3_tests tests/SE3Tests.cpp)
+    target_link_libraries(se3_tests ${PROJECT_NAME})
+    ament_add_gtest(covariance_tests tests/CovarianceTests.cpp)
+    target_link_libraries(covariance_tests ${PROJECT_NAME})
+    ament_add_gtest(rotation_tests tests/RotationTests.cpp)
+    target_link_libraries(rotation_tests ${PROJECT_NAME})
+    ament_add_gtest(se2_transform_tests tests/SE2TransformTests.cpp)
+    target_link_libraries(se2_transform_tests ${PROJECT_NAME})
+    ament_add_gtest(transform_tests tests/TransformTests.cpp)
+    target_link_libraries(transform_tests ${PROJECT_NAME})
+    ament_add_gtest(se2_transform_with_covariance_tests tests/SE2TransformWithCovarianceTests.cpp)
+    target_link_libraries(se2_transform_with_covariance_tests ${PROJECT_NAME})
+    ament_add_gtest(transform_with_covariance_tests tests/TransformWithCovarianceTests.cpp)
+    target_link_libraries(transform_with_covariance_tests ${PROJECT_NAME})
 
-  # Benchmarks
-  ament_add_gtest(so3_benchmarks benchmarks/SO3SpeedTest.cpp)
-  target_link_libraries(so3_benchmarks ${PROJECT_NAME})
-  ament_add_gtest(se3_benchmarks benchmarks/SE3SpeedTest.cpp)
-  target_link_libraries(se3_benchmarks ${PROJECT_NAME})
-  ament_add_gtest(rotation_benchmarks benchmarks/RotationSpeedTest.cpp)
-  target_link_libraries(rotation_benchmarks ${PROJECT_NAME})
-  ament_add_gtest(transform_benchmarks benchmarks/TransformSpeedTest.cpp)
-  target_link_libraries(transform_benchmarks ${PROJECT_NAME})
-  ament_add_gtest(transform_with_covariance_benchmarks benchmarks/TransformWithCovarianceSpeedTest.cpp)
-  target_link_libraries(transform_with_covariance_benchmarks ${PROJECT_NAME})
+    # Benchmarks
+    ament_add_gtest(so3_benchmarks benchmarks/SO3SpeedTest.cpp)
+    target_link_libraries(so3_benchmarks ${PROJECT_NAME})
+    ament_add_gtest(se3_benchmarks benchmarks/SE3SpeedTest.cpp)
+    target_link_libraries(se3_benchmarks ${PROJECT_NAME})
+    ament_add_gtest(rotation_benchmarks benchmarks/RotationSpeedTest.cpp)
+    target_link_libraries(rotation_benchmarks ${PROJECT_NAME})
+    ament_add_gtest(transform_benchmarks benchmarks/TransformSpeedTest.cpp)
+    target_link_libraries(transform_benchmarks ${PROJECT_NAME})
+    ament_add_gtest(transform_with_covariance_benchmarks benchmarks/TransformWithCovarianceSpeedTest.cpp)
+    target_link_libraries(transform_with_covariance_benchmarks ${PROJECT_NAME})
 
-  # Linting
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies() # Lint based on linter test_depend in package.xml
-endif()
+    # Linting
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies() # Lint based on linter test_depend in package.xml
+  endif()
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ mkdir build && cd $_
 cmake .. && make install # default install location is /usr/local/
 ```
 
-- Note: if installed from source to a custom location then make sure `cmake` can find it.
+- Note: if installed from source to a custom location then make sure `cmake` can find it. Also ensure that ros has not been sourced in the terminal used for compilation otherwise it will be compiled as an `ament_cmake` package.
 
 ### Build and install lgmath using `cmake`
 
@@ -61,15 +61,11 @@ Note: `lgmathConfig.cmake` will be generated in both `build/` and `<install pref
 
 ### Build and install lgmath using `ROS2(colcon+ament_cmake)`
 
+CMake will automatically determine if you are building as part of a 
 ```bash
-WORKSPACE=~/workspace  # choose your own workspace directory
-
-mkdir -p ${WORKSPACE}/lgmath && cd $_
-git clone https://github.com/utiasASRL/lgmath.git .
-
-source <your ROS2 worspace>
-colcon build --symlink-install --cmake-args "-DUSE_AMENT=ON"
-colcon build --symlink-install --cmake-args "-DUSE_AMENT=ON" --cmake-target doc  # (optional) generate documentation in ./build/doc
+colcon build
 ```
+and use `ament_cmake` for you. This is achieved checking if ROS is present in your terminal and if the install location is not the default `/usr/local` which is true of ROS packages.
+
 
 ## [License](./LICENSE)


### PR DESCRIPTION
Modified the CMake configuration to look for `ament_cmake`, which is used for building ros2 packages. 
Will remove the ros2 branch after merging.

Resolves #48 .